### PR TITLE
グループ編集機能

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,6 +1,9 @@
 class GroupsController < ApplicationController
   before_action :set_group, only: [:edit, :update]
 
+  def index
+  end
+
   def new
     @group = Group.new
     @group.users << current_user

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,4 +1,6 @@
 class GroupsController < ApplicationController
+  before_action :set_group, only: [:edit, :update]
+
   def new
     @group = Group.new
     @group.users << current_user
@@ -14,16 +16,22 @@ class GroupsController < ApplicationController
   end
 
   def edit
-    @group = Group.find(params[:id])
   end
 
   def update
-    Group.update(group_params)
-    Member.update
+    if @group.update(group_params)
+      redirect_to group_messages_path(@group), notice: 'グループを編集しました'
+    else
+      render :edit
+    end
   end
 
   private
   def group_params
     params.require(:group).permit(:name, { :user_ids => [] })
+  end
+
+  def set_group
+    @group = Group.find(params[:id])
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,5 +1,5 @@
 class MessagesController < ApplicationController
   def index
-    @group = Group.find(6)
+    @group = Group.find(params[:group_id])
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,6 +1,5 @@
 class MessagesController < ApplicationController
   def index
-    @group = Group.find(1)
-    @groups = current_user.groups
+    @group = Group.find(6)
   end
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,0 +1,43 @@
+= form_for group, id: "new_chat_group", class: "new_chat_group" do |f|
+  - if group.errors.any?
+    .chat-group-form__errors
+      %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
+      %ul
+        - group.errors.full_messages.each do |message|
+          %li= message
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      = f.label :name, "グループ名", class: 'chat-group-form__label'
+    .chat-group-form__field--right
+      = f.text_field :name, id: "chat_group_name", class: "chat-group-form__input", placeholder: "グループ名を入力してください"
+  .chat-group-form__field.clearfix
+    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+    /
+      <div class='chat-group-form__field--left'>
+      <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
+      </div>
+      <div class='chat-group-form__field--right'>
+      <div class='chat-group-form__search clearfix'>
+      <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
+      </div>
+      <div id='user-search-result'></div>
+      </div>
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      = f.label "チャットメンバー", class: 'chat-group-form__label'
+    .chat-group-form__field--right
+      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+      = f.collection_check_boxes(:user_ids, User.all, :id, :name) do |user|
+        = user.label {user.check_box + user.text}
+      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+      /
+        <div id='chat-group-users'>
+        <div class='chat-group-user clearfix' id='chat-group-user-22'>
+        <input name='chat_group[user_ids][]' type='hidden' value='22'>
+        <p class='chat-group-user__name'>seo_kyohei</p>
+        </div>
+        </div>
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+    .chat-group-form__field--right
+      = f.submit class: "chat-group-form__action-btn", value: 'Save', html: {"data-disable-with" => "Save"}

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,33 +1,3 @@
 .chat-group-form
   %h1 チャットグループ編集
-  %form#edit_chat_group_22.edit_chat_group{"accept-charset" => "UTF-8", action: "/chat_groups/22", method: "post"}
-    .chat-group-form__errors
-      %h2
-        1件のエラーが発生しました。
-        %ul
-          %li エラーです
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_name"} グループ名
-      .chat-group-form__field--right
-        %input#chat_group_name.chat-group-form__input{name: "chat_group[name]", placeholder: "グループ名を入力してください", type: "text", value: "ほげー"}/
-    .chat-group-form__field.clearfix
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-      /
-        <div class='chat-group-form__field--left'>
-        <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-        </div>
-        <div class='chat-group-form__field--right'>
-        <div class='chat-group-form__search clearfix'>
-        <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-        </div>
-        <div id='user-search-result'></div>
-        </div>
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        %input.chat-group-form__action-btn{"data-disable-with" => "Save", name: "commit", type: "submit", value: "Save"}/
+  = render partial: 'form', locals: { group: @group }

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,0 +1,6 @@
+.wrapper
+  .contents
+    .side-bar
+      = render partial: 'messages/my-account'
+      = render partial: "messages/group"
+    .content

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,47 +1,5 @@
 .chat-group-form
   %h1 新規チャットグループ
-  = form_for @group, id: "new_chat_group", class: "new_chat_group" do |f|
-    - if @group.errors.any?
-      .chat-group-form__errors
-        %h2= "#{@group.errors.full_messages.count}件のエラーが発生しました。"
-        %ul
-          - @group.errors.full_messages.each do |message|
-            %li= message
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        = f.label :name, "グループ名", class: 'chat-group-form__label'
-      .chat-group-form__field--right
-        = f.text_field :name, id: "chat_group_name", class: "chat-group-form__input", placeholder: "グループ名を入力してください"
-    .chat-group-form__field.clearfix
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-      /
-        <div class='chat-group-form__field--left'>
-        <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-        </div>
-        <div class='chat-group-form__field--right'>
-        <div class='chat-group-form__search clearfix'>
-        <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-        </div>
-        <div id='user-search-result'></div>
-        </div>
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        = f.label "チャットメンバー", class: 'chat-group-form__label'
-      .chat-group-form__field--right
-        / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-        = f.collection_check_boxes(:user_ids, User.all, :id, :name) do |user|
-          = user.label {user.check_box + user.text}
-        / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-        /
-          <div id='chat-group-users'>
-          <div class='chat-group-user clearfix' id='chat-group-user-22'>
-          <input name='chat_group[user_ids][]' type='hidden' value='22'>
-          <p class='chat-group-user__name'>seo_kyohei</p>
-          </div>
-          </div>
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        = f.submit class: "chat-group-form__action-btn", value: 'Save', html: {"data-disable-with" => "Save"}
+  = render partial: 'form', locals: { group: @group }
 
 

--- a/app/views/messages/_current-group.html.haml
+++ b/app/views/messages/_current-group.html.haml
@@ -1,4 +1,8 @@
 .content__current-group
-  %p.content__current-group__name group1
-  %p.content__current-group__members Member : yosukenn, yasuda
+  %p.content__current-group__name= @group.name
+  %p.content__current-group__members
+    Member:
+    - @group.users.each do |user|
+      %span
+      = user.name
   = link_to "Edit", edit_group_path(@group), class: "content__current-group__edit"

--- a/app/views/messages/_group.html.haml
+++ b/app/views/messages/_group.html.haml
@@ -1,5 +1,5 @@
 .side-bar__group
-  - @groups.each do |group|
+  - current_user.groups.each do |group|
     = link_to group_messages_path(group), class: 'side-bar__group__link' do
       .side-bar__group__name
         = group.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  root 'messages#index'
+  root 'groups#index'
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]


### PR DESCRIPTION
#What
・編集フォームの編集
・コントローラ内の処理の追加
・index画面からの遷移、任意のグループ編集画面に跳べているか
・編集成功、失敗時のメッセージと画面の遷移

#Why
・チャットグループの名前、メンバーを編集できるようにする
→メッセージ送信機能に移るため