### PR TITLE
インクリメンタルリサーチの実装

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -1,5 +1,7 @@
 $(function() {
 
+  var preInput;
+
   function appendUser(user) {
     var html = `<div class="chat-group-user clearfix">
                   <p class="chat-group-user__name">${user.name}</p>
@@ -33,6 +35,7 @@ $(function() {
       dataType: 'json'
     })
     .done(function(users) {
+      if (input !== preInput) {
       $('#user-search-result').empty();
       if (users.length !== 0) {
         users.forEach(function(user) {
@@ -40,6 +43,8 @@ $(function() {
         });
       } else {
         appendNoUser("一致するユーザーはいません。")
+      }
+      preInput = input;
       }
     })
     .fail(function() {

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -15,10 +15,10 @@ $(function() {
     $('#user-search-result').append(html);
   }
 
-  function appendMember(id, name) {
+  function appendMember(user) {
     var html = `<div class='chat-group-user clearfix js-chat-member' id='chat-group-user-8'>
-                  <input name='group[user_ids][]' type='hidden' value=${id}>
-                  <p class='chat-group-user__name'>${name}</p>
+                  <input name='group[user_ids][]' type='hidden' value=${user.userId}>
+                  <p class='chat-group-user__name'>${user.userName}</p>
                   <a class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</a>
                   </div>`
     $('#chat-group-users').append(html);
@@ -50,10 +50,10 @@ $(function() {
   $('#user-search-result').on('click', '.user-search-add', function() {
     $(this).parent().remove();
     // 選択されたユーザー情報を取得する
-    var id = $(this).attr('data-user-id');
-    var name = $(this).attr('data-user-name');
+    var user = $(this).data();
+    console.log(user);
     // HTMLを追加する関数に渡す
-    appendMember(id, name);
+    appendMember(user);
   })
 
   $('#chat-group-users').on('click', '.chat-group-user__btn', function() {

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -39,6 +39,7 @@ $(function() {
   });
 
   $('.user-search-result').on('click', '.user-search-add', function() {
+    $(this).parent().remove();
 
 
   })

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -19,8 +19,8 @@ $(function() {
 
   function appendMember(user) {
     var html = `<div class='chat-group-user clearfix js-chat-member' id='chat-group-user-8'>
-                  <input name='group[user_ids][]' type='hidden' value=${user.userId}>
-                  <p class='chat-group-user__name'>${user.userName}</p>
+                  <input name='group[user_ids][]' type='hidden' value=${user.id}>
+                  <p class='chat-group-user__name'>${user.name}</p>
                   <a class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</a>
                   </div>`
     $('#chat-group-users').append(html);
@@ -55,7 +55,7 @@ $(function() {
   $('#user-search-result').on('click', '.user-search-add', function() {
     $(this).parent().remove();
     // 選択されたユーザー情報を取得する
-    var user = $(this).data();
+    var user = { id: $(this).data('userId'), name: $(this).data('userName') };
     // HTMLを追加する関数に渡す
     appendMember(user);
   })

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -1,0 +1,10 @@
+$(function() {
+  $('.chat-group-form__input').on('keyup', function() {
+    var input = $(this).val();
+    console.log(input)
+
+
+  });
+
+
+});

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -5,14 +5,14 @@ $(function() {
                   <p class="chat-group-user__name">${user.name}</p>
                   <a class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id=${user.id} data-user-name=${user.name}>追加</a>
                 </div>`
-    $('.user-search-result').append(html);
+    $('#user-search-result').append(html);
   }
 
   function appendNoUser(user) {
     var html = `<div class="chat-group-user clearfix">
                   <p class="chat-group-user__name">${user}</p>
                 </div>`
-    $('.user-search-result').append(html);
+    $('#user-search-result').append(html);
   }
 
   function appendMember(id, name) {
@@ -33,7 +33,7 @@ $(function() {
       dataType: 'json'
     })
     .done(function(users) {
-      $('.user-search-result').empty();
+      $('#user-search-result').empty();
       if (users.length !== 0) {
         users.forEach(function(user) {
           appendUser(user);
@@ -47,7 +47,7 @@ $(function() {
     })
   });
 
-  $('.user-search-result').on('click', '.user-search-add', function() {
+  $('#user-search-result').on('click', '.user-search-add', function() {
     $(this).parent().remove();
     // 選択されたユーザー情報を取得する
     var id = $(this).attr('data-user-id');

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -1,10 +1,45 @@
 $(function() {
+
+  function appendUser(user) {
+    var html = `<div class="chat-group-user clearfix">
+                  <p class="chat-group-user__name">${user.name}</p>
+                  <a class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id=${user.id} data-user-name=${user.name}>追加</a>
+                </div>`
+    $('.user-search-result').append(html);
+  }
+
+  function appendNoUser(user) {
+    var html = `<div class="chat-group-user clearfix">
+                  <p class="chat-group-user__name">${user}</p>
+                </div>`
+    $('.user-search-result').append(html);
+  }
+
   $('.chat-group-form__input').on('keyup', function() {
     var input = $(this).val();
-    console.log(input)
+
+    $.ajax({
+      type: 'GET',
+      url: '/users',
+      data: { keyword: input },
+      dataType: 'json'
+    })
+
+    .done(function(users) {
+      $('.user-search-result').empty();
+      if (users.length !== 0) {
+        users.forEach(function(user) {
+          appendUser(user);
+        });
+      } else {
+        appendNoUser("一致するユーザーはいません。")
+      }
+    })
+
+    .fail(function() {
+      alert('通信に失敗しました。')
+    })
 
 
   });
-
-
 });

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -28,6 +28,7 @@ $(function() {
 
   $('#user-search-field').on('keyup', function() {
     var input = $(this).val();
+    if (input !== preInput && input.length !== 0) {
     $.ajax({
       type: 'GET',
       url: '/users',
@@ -35,7 +36,6 @@ $(function() {
       dataType: 'json'
     })
     .done(function(users) {
-      if (input !== preInput && input.length !== 0) {
       $('#user-search-result').empty();
       if (users.length !== 0) {
         users.forEach(function(user) {
@@ -45,11 +45,13 @@ $(function() {
         appendNoUser("一致するユーザーはいません。")
       }
       preInput = input;
-      }
     })
     .fail(function() {
       alert('通信に失敗しました。')
     })
+    } else if (input.length === 0) {
+      $('#user-search-result').remove();
+    }
   });
 
   $('#user-search-result').on('click', '.user-search-add', function() {

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -24,7 +24,7 @@ $(function() {
     $('#chat-group-users').append(html);
   }
 
-  $('.chat-group-form__input').on('keyup', function() {
+  $('#user-search-field').on('keyup', function() {
     var input = $(this).val();
     $.ajax({
       type: 'GET',

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -56,7 +56,7 @@ $(function() {
     appendMember(user);
   })
 
-  $('#chat-group-users').on('click', '.chat-group-user__btn', function() {
+  $('#chat-group-users').on('click', '.js-remove-btn', function() {
     $(this).parent().remove();
   })
 });

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -17,14 +17,12 @@ $(function() {
 
   $('.chat-group-form__input').on('keyup', function() {
     var input = $(this).val();
-
     $.ajax({
       type: 'GET',
       url: '/users',
       data: { keyword: input },
       dataType: 'json'
     })
-
     .done(function(users) {
       $('.user-search-result').empty();
       if (users.length !== 0) {
@@ -35,11 +33,16 @@ $(function() {
         appendNoUser("一致するユーザーはいません。")
       }
     })
-
     .fail(function() {
       alert('通信に失敗しました。')
     })
-
-
   });
+
+  $('.user-search-result').on('click', '.user-search-add', function() {
+
+
+  })
+
+
+
 });

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -35,7 +35,7 @@ $(function() {
       dataType: 'json'
     })
     .done(function(users) {
-      if (input !== preInput) {
+      if (input !== preInput && input.length !== 0) {
       $('#user-search-result').empty();
       if (users.length !== 0) {
         users.forEach(function(user) {

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -56,6 +56,7 @@ $(function() {
     appendMember(id, name);
   })
 
-
-
+  $('#chat-group-users').on('click', '.chat-group-user__btn', function() {
+    $(this).parent().remove();
+  })
 });

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -15,6 +15,15 @@ $(function() {
     $('.user-search-result').append(html);
   }
 
+  function appendMember(id, name) {
+    var html = `<div class='chat-group-user clearfix js-chat-member' id='chat-group-user-8'>
+                  <input name='group[user_ids][]' type='hidden' value=${id}>
+                  <p class='chat-group-user__name'>${name}</p>
+                  <a class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</a>
+                  </div>`
+    $('#chat-group-users').append(html);
+  }
+
   $('.chat-group-form__input').on('keyup', function() {
     var input = $(this).val();
     $.ajax({
@@ -40,8 +49,11 @@ $(function() {
 
   $('.user-search-result').on('click', '.user-search-add', function() {
     $(this).parent().remove();
-
-
+    // 選択されたユーザー情報を取得する
+    var id = $(this).attr('data-user-id');
+    var name = $(this).attr('data-user-name');
+    // HTMLを追加する関数に渡す
+    appendMember(id, name);
   })
 
 

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -56,7 +56,6 @@ $(function() {
     $(this).parent().remove();
     // 選択されたユーザー情報を取得する
     var user = $(this).data();
-    console.log(user);
     // HTMLを追加する関数に渡す
     appendMember(user);
   })

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,13 @@
 class UsersController < ApplicationController
 
+  def index
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
   def edit
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
 
   def index
-    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").where.not(id: current_user.id)
     respond_to do |format|
       format.html
       format.json

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -22,9 +22,6 @@
     .chat-group-form__field--left
       = f.label "チャットメンバー", class: 'chat-group-form__label'
     .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      / = f.collection_check_boxes(:user_ids, User.all, :id, :name) do |user|
-      /   = user.label {user.check_box + user.text}
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
       #chat-group-users
         - group.users.each do |user|

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -27,10 +27,12 @@
       /   = user.label {user.check_box + user.text}
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
       #chat-group-users
-        .chat-group-user.clearfix#chat-group-user-22
-          = f.hidden_field :user_ids, value: '22'
-          %p.chat-group-user__name
-          seo_kyohei
+        - group.users.each do |user|
+          .chat-group-user.clearfix#chat-group-user-22
+            = f.fields_for user do |u|
+              = u.hidden_field :user_ids, name:"group[user_ids][]", value: user.id
+              %p.chat-group-user__name
+              = user.name
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -17,7 +17,7 @@
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
         %input.chat-group-form__input#user-search-field{placeholder: '追加したいユーザー名を入力してください', type: 'text'}
-    .user-search-result
+      .user-search-result
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       = f.label "チャットメンバー", class: 'chat-group-form__label'

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -33,6 +33,7 @@
               = u.hidden_field :user_ids, name:"group[user_ids][]", value: user.id
               %p.chat-group-user__name
               = user.name
+              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 削除
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -17,7 +17,7 @@
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
         %input.chat-group-form__input#user-search-field{placeholder: '追加したいユーザー名を入力してください', type: 'text'}
-      .user-search-result
+      #user-search-result
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       = f.label "チャットメンバー", class: 'chat-group-form__label'

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -12,31 +12,25 @@
       = f.text_field :name, id: "chat_group_name", class: "chat-group-form__input", placeholder: "グループ名を入力してください"
   .chat-group-form__field.clearfix
     / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-    /
-      <div class='chat-group-form__field--left'>
-      <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-      </div>
-      <div class='chat-group-form__field--right'>
-      <div class='chat-group-form__search clearfix'>
-      <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-      </div>
-      <div id='user-search-result'></div>
-      </div>
+    .chat-group-form__field--left
+      = f.label "チャットメンバーを追加", class: 'chat-group-form__label'
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        %input.chat-group-form__input#user-search-field{placeholder: '追加したいユーザー名を入力してください', type: 'text'}
+    .user-search-result
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       = f.label "チャットメンバー", class: 'chat-group-form__label'
     .chat-group-form__field--right
       / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes(:user_ids, User.all, :id, :name) do |user|
-        = user.label {user.check_box + user.text}
+      / = f.collection_check_boxes(:user_ids, User.all, :id, :name) do |user|
+      /   = user.label {user.check_box + user.text}
       / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-      /
-        <div id='chat-group-users'>
-        <div class='chat-group-user clearfix' id='chat-group-user-22'>
-        <input name='chat_group[user_ids][]' type='hidden' value='22'>
-        <p class='chat-group-user__name'>seo_kyohei</p>
-        </div>
-        </div>
+      #chat-group-users
+        .chat-group-user.clearfix#chat-group-user-22
+          = f.hidden_field :user_ids, value: '22'
+          %p.chat-group-user__name
+          seo_kyohei
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end


### PR DESCRIPTION
#What
グループ作成画面の、ユーザー検索に、インクリメンタル リサーチを実装
　1. ルーティングなどAPI側の準備をする
    2. テキストフィールドを作成する
    3. テキストフィールドに入力されるたびにイベントが発火するようにする
    4. イベント時に非同期通信できるようにする
    5. 非同期通信の結果を得て、HTMLを作成する
    6. エラー時の処理を行う

インクリメンタルリサーチの検索結果から、ユーザーをグループの一員として登録する処理
（groups#createへのparamsに、任意のユーザーのidを含ませる）
　1. 追加を押されたときにイベントが発火するようにする
　2. 検索結果からHTMLを消し、チャットメンバーの部分にHTMLを追加する
　3. 削除を押すと、チャットメンバーから削除する

#Why
UX向上