### PR TITLE
メッセージ画面のレイアウトバグ修正

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -26,7 +26,7 @@ $(function() {
   $('.new_message').on('submit', function(e) {
     e.preventDefault();
     var formData = new FormData(this);
-    var url = $(this).attr('action')
+    var url = $(this).attr('action');
     $.ajax({
       url: url,
       type: 'POST',
@@ -36,6 +36,10 @@ $(function() {
       contentType: false
     })
     .done(function(data) {
+      if (data.length == 0) {
+        $('.content__message-send__content__btn').removeAttr('disabled');
+        return false;
+      }
       var html = buildHTML(data);
       $('.content__message').append(html);
       $('.new_message')[0].reset();

--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -59,7 +59,7 @@
       color: $black;
     }
     &__image {
-      float: left;
+      clear: left;
       max-width: 200px;
       max-height: 100px;
     }

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -3,6 +3,5 @@
     .content__message__block{data: {id: message.id}}
       .content__message__name= message.user.name
       %p.content__message__date= format_posted_time(message.created_at)
-      - if message.body.present?
-        %p.content__message__text= message.body
+      %p.content__message__text= message.body
       = image_tag message.image.url, class: 'content__message__image' if message.image.present?

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -2,6 +2,6 @@
   - @messages.each do |message|
     .content__message__block{data: {id: message.id}}
       .content__message__name= message.user.name
-      %p.content__message__date= format_posted_time(message.created_at)
+      %p.content__message__date= message.created_at.to_s(:sent_on)
       %p.content__message__text= message.body
       = image_tag message.image.url, class: 'content__message__image' if message.image.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,5 @@
 json.id @message.id
 json.body @message.body
 json.user_name @message.user.name
-json.created_at format_posted_time(@message.created_at)
+json.created_at @message.created_at.to_s(:sent_on)
 json.image @message.image

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,3 @@
+# カスタムフォーマットを定義
+Time::DATE_FORMATS[:sent_on] = "%Y年%m月%d日 %H時%M分"
+Date::DATE_FORMATS[:default] = "%Y年%m月d日"


### PR DESCRIPTION
#What
Must
・画像のレイアウト（完了）
・時間の表記（完了）
Strech
・グループ一覧をメッセージが最新のもの順にしたい
・グループ編集のインクリメンタル サーチで、すでにいるユーザは候補に表示したくない
・空でSendを押した後、メッセージが送れない（完了）

#why
メッセージ画面の見た目を整える